### PR TITLE
fix: added missing css file to show style changes on component page

### DIFF
--- a/src/app/components/layout.tsx
+++ b/src/app/components/layout.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next';
 import * as React from 'react';
 
+import '@/styles/colors.css';
+
 export const metadata: Metadata = {
   title: 'Components',
   description: 'Pre-built components with awesome default',


### PR DESCRIPTION
# Description & Technical Solution

The components page drop down only changed the class name on the page - it does not show the color theme update, as the css file is not loaded, so you can change the value in the drop down, but nothing changes in the UI.

We fix this by importing the color.css file in the components page.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] Already rebased against main branch.

# Screenshots

Provide screenshots or videos of the changes made if any.
