### PR TITLE
fix: prevent Prettier formatting CSS files adding spaces after a single colon

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit"
   },
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   // Tailwind CSS Autocomplete, add more if used in projects
   "tailwindCSS.classAttributes": [
     "class",


### PR DESCRIPTION
When editing the `globals.css` file, Prettier automatically formats the code from `md:text-5xl` to `md: text-5xl`, adding a space after a single colon. This behavior is not desired.