### PR TITLE
Update Next.js version from 13 to 14 in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 This repository is 🔋 battery packed with:
 
-- ⚡️ Next.js 13 with App Router
+- ⚡️ Next.js 14 with App Router
 - ⚛️ React 18
 - ✨ TypeScript
 - 💨 Tailwind CSS 3 — Configured with CSS Variables to extend the **primary** color


### PR DESCRIPTION
# Description & Technical Solution

Update Next.js version from 13 to 14 in the readme as it was updated in https://github.com/theodorusclarence/ts-nextjs-tailwind-starter/pull/257
