### PR TITLE
chore(nextconfig): update nextconfig image domains to remotepatterns

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,9 +9,12 @@ const nextConfig = {
 
   // Uncoment to add domain whitelist
   // images: {
-  //   domains: [
-  //     'res.cloudinary.com',
-  //   ],
+  //   remotePatterns: [
+  //     {
+  //       protocol: 'https',
+  //       hostname: 'res.cloudinary.com',
+  //     },
+  //   ]
   // },
 
   webpack(config) {


### PR DESCRIPTION
# Description & Technical Solution

issue: Deprecated nextconfig images domains
solution: change nextconfig images domains to remotepatterns 
source: https://nextjs.org/docs/app/api-reference/components/image#remotepatterns

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] Already rebased against main branch.

# Screenshots
![image](https://github.com/user-attachments/assets/fbb71880-eb43-4447-8882-798d2f39140e)
