### PR TITLE
docs: update README page path to App Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can start the server using this command:
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. You can start editing the page by modifying `src/pages/index.tsx`.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. You can start editing the page by modifying `src/app/page.tsx`.
 
 ### 4. Change defaults
 


### PR DESCRIPTION
The README says to edit src/pages/index.tsx, but this starter is on the App Router. src/pages/ no longer exists and the home page rendered at / is src/app/page.tsx. Updated the instruction to match.
